### PR TITLE
Added boilerplate

### DIFF
--- a/Majorcord.py
+++ b/Majorcord.py
@@ -1,3 +1,16 @@
+ ''' Copyright 2018 Thomas Frew
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.  '''
+
 #Imports modules
 from tkinter import *
 from time import *


### PR DESCRIPTION
## `boilerplate-1`: added boilerplate to `Majorcord.py` on `master`
* Added the Apache.20 boilterplate to `Majorcord.py` so that it is properly licensed.
* +13 new lines of boilerplate written in triple apostrophes. `'''`
* @ThomasFrew just that guy!
* Nope: no issues!

- [x] I have read and understand the [Code of Conduct](https://github.com/ThomasFrew/Majorcord/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/ThomasFrew/Majorcord).
